### PR TITLE
Ecmascript20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ App_Data/
 *.ncrunchsolution
 MainAssemblies
 output
+.vs

--- a/Build/NuGetPackageBuild.proj
+++ b/Build/NuGetPackageBuild.proj
@@ -98,7 +98,7 @@
             <MSBuildBinaries Include="$(Src)\MainAssemblies\EcmaScript.NET.dll" />
         </ItemGroup>
 
-        <Copy SourceFiles="@(MSBuildBinaries)" DestinationFolder="$(PackageTempFilesDir)\lib\NET20" />
+        <Copy SourceFiles="@(MSBuildBinaries)" DestinationFolder="$(PackageTempFilesDir)\lib\NET45" />
         <Copy SourceFiles="$(MSBuildProjectDirectory)\NuSpecs\$(OriginalNuSpecFile)" DestinationFiles="$(PackageTempDir)\$(NewNuSpecFile)" />
         <Copy SourceFiles="$(Src)\Build\SampleYuiCompressorMsBuild.proj" DestinationFiles="$(PackageTempFilesDir)\Sample-YuiCompressorMsBuild.proj" />
         <Copy SourceFiles="$(Src)\Build\ReadMe-Core.txt" DestinationFiles="$(PackageTempFilesDir)\readme.txt" />
@@ -131,7 +131,7 @@ This is a direct .NET port of the original Yahoo! UI Library: YUI Compressor." /
             <NAntBinaries Include="$(Src)\MainAssemblies\EcmaScript.NET.dll" />
         </ItemGroup>
         
-        <Copy SourceFiles="@(NAntBinaries)" DestinationFolder="$(PackageTempFilesDir)\lib\NET20" />
+        <Copy SourceFiles="@(NAntBinaries)" DestinationFolder="$(PackageTempFilesDir)\lib\NET45" />
         <Copy SourceFiles="$(MSBuildProjectDirectory)\NuSpecs\$(NuSpecFile)" DestinationFiles="$(PackageTempDir)\$(NuSpecFile)" />
         <Copy SourceFiles="$(Src)\Build\New BSD License.txt" DestinationFiles="$(PackageTempFilesDir)\New BSD License.txt" />
         

--- a/Build/NuSpecs/YUICompressor.NET.MSBuild.NAnt.nuspec
+++ b/Build/NuSpecs/YUICompressor.NET.MSBuild.NAnt.nuspec
@@ -19,8 +19,8 @@ This is a direct .NET port of the original Yahoo! UI Library: YUI Compressor.</d
         <language>en-au</language>
         <tags>compression, compressor, minification, obfuscation, minify, bundle, bundler, combine, javascript, js, CSS, cascading style sheets</tags>
         <dependencies>
-            <dependency id="EcmaScript.Net" version="1.0.1.0" />
-            <dependency id="YUICompressor.NET" version="[2.0.0.0, 3.0.0.0)" />
+            <dependency id="EcmaScript.Net" version="2.0.0.0" />
+            <dependency id="YUICompressor.NET" version="3.0.0.0" />
         </dependencies>
     </metadata>
     <files>

--- a/Build/NuSpecs/YUICompressor.NET.Web.Optimization.nuspec
+++ b/Build/NuSpecs/YUICompressor.NET.Web.Optimization.nuspec
@@ -21,10 +21,10 @@ This is a direct .NET port of the original Yahoo! UI Library: YUI Compressor.</d
         <language>en-au</language>
         <tags>compression, compressor, minification, obfuscation, minify, bundle, bundler, combine, javascript, js, CSS, cascading style sheets, optimization, transform</tags>
         <dependencies>
-            <dependency id="EcmaScript.Net" version="1.0.1.0" />
+            <dependency id="EcmaScript.Net" version="2.0.0.0" />
             <dependency id="Microsoft.AspNet.Web.Optimization" version="[1.1.3, 2.0.0.0)" />
             <dependency id="WebGrease" version="[1.6.0, 2.0.0.0)" />
-            <dependency id="YUICompressor.NET" version="[2.0.0.0, 3.0.0.0)" />
+            <dependency id="YUICompressor.NET" version="3.0.0.0" />
         </dependencies>
     </metadata>
     <files>

--- a/Build/NuSpecs/YUICompressor.NET.nuspec
+++ b/Build/NuSpecs/YUICompressor.NET.nuspec
@@ -19,7 +19,7 @@ This is a direct .NET port of the original Yahoo! UI Library: YUI Compressor.</d
         <language>en-au</language>
         <tags>compression, compressor, minification, obfuscation, minify, bundle, bundler, combine, javascript, js, CSS, cascading style sheets</tags>
         <dependencies>
-            <dependency id="EcmaScript.Net" version="1.0.1.0" />
+            <dependency id="EcmaScript.Net" version="2.0.0.0" />
         </dependencies>
     </metadata>
     <files>

--- a/Build/SampleYuiCompressorMsBuild.proj
+++ b/Build/SampleYuiCompressorMsBuild.proj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/MsBuild/2003">
 
-  <UsingTask TaskName="CssCompressorTask" AssemblyFile="..\..\lib\NET20\Yahoo.Yui.Compressor.Build.MsBuild.dll" />
-  <UsingTask TaskName="JavaScriptCompressorTask" AssemblyFile="..\..\lib\NET20\Yahoo.Yui.Compressor.Build.MsBuild.dll" />
+  <UsingTask TaskName="CssCompressorTask" AssemblyFile="..\..\lib\NET45\Yahoo.Yui.Compressor.Build.MsBuild.dll" />
+  <UsingTask TaskName="JavaScriptCompressorTask" AssemblyFile="..\..\lib\NET45\Yahoo.Yui.Compressor.Build.MsBuild.dll" />
 
   
   <!-- 

--- a/Code/Shared Assembly Info/SharedAssemblyInfo.cs
+++ b/Code/Shared Assembly Info/SharedAssemblyInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.7.0.0")]
-[assembly: AssemblyFileVersion("2.7.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]

--- a/Code/Yahoo.Yui.Compressor.Build.MsBuild/Yahoo.Yui.Compressor.Build.MsBuild.csproj
+++ b/Code/Yahoo.Yui.Compressor.Build.MsBuild/Yahoo.Yui.Compressor.Build.MsBuild.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Yahoo.Yui.Compressor.Build.MsBuild</RootNamespace>
     <AssemblyName>Yahoo.Yui.Compressor.Build.MsBuild</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -47,9 +49,8 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EcmaScript.NET">
-      <HintPath>..\..\packages\EcmaScript.Net.1.0.1.0\lib\net20\EcmaScript.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EcmaScript.NET, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EcmaScript.NET.2.0.0\lib\net45\EcmaScript.NET.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities" />

--- a/Code/Yahoo.Yui.Compressor.Build.MsBuild/packages.config
+++ b/Code/Yahoo.Yui.Compressor.Build.MsBuild/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EcmaScript.Net" version="1.0.1.0" targetFramework="net20" />
+  <package id="EcmaScript.NET" version="2.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/Code/Yahoo.Yui.Compressor.Build.Nant/Yahoo.Yui.Compressor.Build.Nant.csproj
+++ b/Code/Yahoo.Yui.Compressor.Build.Nant/Yahoo.Yui.Compressor.Build.Nant.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Yahoo.Yui.Compressor.Build.Nant</RootNamespace>
     <AssemblyName>Yahoo.Yui.Compressor.Build.Nant</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -18,6 +18,7 @@
     <SccProvider>SAK</SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\YUICompressor\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,11 +39,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EcmaScript.NET">
-      <HintPath>..\..\packages\EcmaScript.Net.1.0.1.0\lib\net20\EcmaScript.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EcmaScript.NET, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EcmaScript.NET.2.0.0\lib\net45\EcmaScript.NET.dll</HintPath>
     </Reference>
     <Reference Include="NAnt.Core, Version=0.91.4312.0, Culture=neutral">
       <SpecificVersion>False</SpecificVersion>
@@ -78,9 +80,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Code/Yahoo.Yui.Compressor.Build.Nant/packages.config
+++ b/Code/Yahoo.Yui.Compressor.Build.Nant/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EcmaScript.Net" version="1.0.1.0" targetFramework="net20" />
+  <package id="EcmaScript.NET" version="2.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/Code/Yahoo.Yui.Compressor.Tests/Yahoo.Yui.Compressor.Tests.csproj
+++ b/Code/Yahoo.Yui.Compressor.Tests/Yahoo.Yui.Compressor.Tests.csproj
@@ -46,9 +46,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="EcmaScript.NET">
-      <HintPath>..\..\packages\EcmaScript.Net.1.0.1.0\lib\net20\EcmaScript.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EcmaScript.NET, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EcmaScript.NET.2.0.0\lib\net45\EcmaScript.NET.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy">
       <HintPath>..\..\packages\FakeItEasy.1.23.0\lib\net40\FakeItEasy.dll</HintPath>

--- a/Code/Yahoo.Yui.Compressor.Tests/packages.config
+++ b/Code/Yahoo.Yui.Compressor.Tests/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="EcmaScript.Net" version="1.0.1.0" targetFramework="net45" />
+  <package id="EcmaScript.NET" version="2.0.0" targetFramework="net45" />
   <package id="FakeItEasy" version="1.23.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="Shouldly" version="2.1.1" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />
 </packages>

--- a/Code/Yahoo.Yui.Compressor.Web.Optimization/Yahoo.Yui.Compressor.Web.Optimization.csproj
+++ b/Code/Yahoo.Yui.Compressor.Web.Optimization/Yahoo.Yui.Compressor.Web.Optimization.csproj
@@ -45,9 +45,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="EcmaScript.NET">
-      <HintPath>..\..\packages\EcmaScript.Net.1.0.1.0\lib\net20\EcmaScript.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EcmaScript.NET, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EcmaScript.NET.2.0.0\lib\net45\EcmaScript.NET.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/Code/Yahoo.Yui.Compressor.Web.Optimization/packages.config
+++ b/Code/Yahoo.Yui.Compressor.Web.Optimization/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="EcmaScript.Net" version="1.0.1.0" targetFramework="net45" />
+  <package id="EcmaScript.NET" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />
 </packages>

--- a/Code/Yahoo.Yui.Compressor/Yahoo.Yui.Compressor.csproj
+++ b/Code/Yahoo.Yui.Compressor/Yahoo.Yui.Compressor.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Yahoo.Yui.Compressor</RootNamespace>
     <AssemblyName>Yahoo.Yui.Compressor</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -52,6 +52,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -62,14 +63,14 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EcmaScript.NET">
-      <HintPath>..\..\packages\EcmaScript.Net.1.0.1.0\lib\net20\EcmaScript.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EcmaScript.NET, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EcmaScript.NET.2.0.0\lib\net45\EcmaScript.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Code/Yahoo.Yui.Compressor/packages.config
+++ b/Code/Yahoo.Yui.Compressor/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EcmaScript.Net" version="1.0.1.0" targetFramework="net20" />
+  <package id="EcmaScript.NET" version="2.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/YUICompressor.sln
+++ b/YUICompressor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2042
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yahoo.Yui.Compressor", "Code\Yahoo.Yui.Compressor\Yahoo.Yui.Compressor.csproj", "{AFDF50F0-286B-4490-9EBD-007561864738}"
 EndProject
@@ -47,6 +47,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {84862C5A-6B13-4426-9683-000AA8E8F30F}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = YUICompressor.vsmdi

--- a/YUICompressor.sln.DotSettings
+++ b/YUICompressor.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
 &#xD;
 &lt;!--&#xD;
@@ -222,7 +223,15 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 &lt;/Patterns&gt;&#xD;
 </s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/PsiConfiguration/LocationType/@EntryValue">TEMP_FOLDER</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/TextControl/HighlightCurrentLine/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=Jasmine/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=MSTest/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Fixes #29 by updating EcmaScript.NET reference

Had to update to Net4.5

I've had to drop CLS compliance because EcmaScript.NET now isnt CLS compliant under Net4.5.

I'd like to see this not be a problem for a 3.0.0.0 (maybe pre-release) version. I'll help get a new version of EcmaScript.NET CLS compliant in the background, but for now I'd really benefit from a YUIC that doesnt have this bug